### PR TITLE
change to 3.5-turbo

### DIFF
--- a/.github/workflows/openai-pr-reviewer.yml
+++ b/.github/workflows/openai-pr-reviewer.yml
@@ -27,3 +27,5 @@ jobs:
           debug: false
           review_simple_changes: false
           review_comment_lgtm: false
+          openai_light_model: gpt-3.5-turbo-0613
+          openai_heavy_model: gpt-3.5-turbo-0613


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- New Feature: Added new configuration options `openai_light_model` and `openai_heavy_model` with the value "gpt-3.5-turbo-0613" to `.github/workflows/openai-pr-reviewer.yml`.

> "In the realm of code, a new feature takes flight,
> With options for models shining bright.
> GPT-3.5 Turbo, the power it brings,
> Enhancing our workflows, like soaring wings."
<!-- end of auto-generated comment: release notes by openai -->