### PR TITLE
Add two-finger pinch zoom for touch controls

### DIFF
--- a/godot-project/3DViewer/Camera.gd
+++ b/godot-project/3DViewer/Camera.gd
@@ -24,6 +24,8 @@ var camera_rotation_v = 0.0
 var camera_zoom_ratio = 1.0
 var camera_zoom_change_ratio = 0.95
 var enable_camera_rotation = false
+var touch_points := {}
+var prev_pinch_distance := -1.0
 
 # --- Small helpers for readability (pure accessors, no logic change) ---
 func _mode_name(idx: int) -> String:
@@ -90,3 +92,23 @@ func _unhandled_input(event):
 			camera_zoom_ratio *= 2.0 - camera_zoom_change_ratio
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			enable_camera_rotation = event.pressed
+
+	# Track screen touches for pinch zoom
+	if event is InputEventScreenTouch:
+		if event.pressed:
+			touch_points[event.index] = event.position
+		else:
+			touch_points.erase(event.index)
+		if touch_points.size() != 2:
+			prev_pinch_distance = -1.0
+
+	# Two-finger pinch to zoom on touch devices
+	if event is InputEventScreenDrag:
+		if touch_points.has(event.index):
+			touch_points[event.index] = event.position
+		if touch_points.size() == 2:
+			var points = touch_points.values()
+			var pinch_distance = points[0].distance_to(points[1])
+			if prev_pinch_distance > 0.0 and pinch_distance > 0.0:
+				camera_zoom_ratio *= prev_pinch_distance / pinch_distance
+			prev_pinch_distance = pinch_distance


### PR DESCRIPTION
### Motivation
- Enable pinch-to-zoom on touch devices for the 3D viewer so users can zoom with two-finger gestures in addition to existing mouse wheel controls.
- Keep existing mouse-based rotation and wheel zoom behavior unchanged while adding touch-specific state to avoid interaction conflicts.

### Description
- Added touch tracking state variables `touch_points` and `prev_pinch_distance` in `godot-project/3DViewer/Camera.gd` to hold active finger positions and the previous pinch baseline.
- Implemented `InputEventScreenTouch` handling to register and remove touch indices and to reset the pinch baseline when the active touch count is not exactly two.
- Implemented `InputEventScreenDrag` handling that updates tracked touch positions and computes two-finger pinch distance changes to update `camera_zoom_ratio` for zooming.
- Preserved all original mouse behaviors (drag rotation and wheel zoom) and existing view-mode logic.

### Testing
- No automated tests were run for this GDScript touch interaction change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad93b7af38832aa81158be73208f7b)