### PR TITLE
Add UI toggle for object icon visibility and wire into DynamicObjectMesh

### DIFF
--- a/godot-project/3DViewer/DynamicObject/DynamicObjectMesh.gd
+++ b/godot-project/3DViewer/DynamicObject/DynamicObjectMesh.gd
@@ -4,6 +4,7 @@ class_name DynamicObjectRenderer
 # ================== Editor-exposed settings ==================
 var ignore_unknown_object: bool
 @export var ignore_unknown_object_toggle: BaseButton
+@export var icon_visibility_toggle: BaseButton
 var object_3d_model_mode: bool
 
 @export var initial_pool: int = 16     # Initial pool size per type
@@ -70,6 +71,8 @@ func _ready() -> void:
 
 	# Synchronize UI status
 	ignore_unknown_object = ignore_unknown_object_toggle.button_pressed
+	if icon_visibility_toggle != null:
+		show_icons = icon_visibility_toggle.button_pressed
 	
 	# Initialize pools
 	_initialize_model_pools(initial_pool)
@@ -133,9 +136,6 @@ func _render_models(objects: Array) -> void:
 				speed_mps = vel.length()
 			node.set_meta("speed_mps", speed_mps)
 
-		# Also place an icon above this object
-		if show_icons:
-			_place_icon_for_object(t, pos, size)
 
 	_hide_unused_nodes()
 
@@ -362,6 +362,12 @@ func _apply_ground_offset(pos: Vector3, size: Vector3) -> Vector3:
 # ------------------ UI callbacks ------------------
 func set_3d_model_mode(enabled: bool) -> void:
 	object_3d_model_mode = enabled
+
+func set_icon_visibility(enabled: bool) -> void:
+	show_icons = enabled
+	if not show_icons:
+		_reset_icon_usage_counters()
+		_hide_unused_icons()
 
 func _on_ignore_unknown_object_toggle_toggled(toggled_on):
 	ignore_unknown_object = toggled_on

--- a/godot-project/3DViewer/Main.tscn
+++ b/godot-project/3DViewer/Main.tscn
@@ -288,11 +288,12 @@ material_override = SubResource("24")
 mesh = SubResource("23")
 script = ExtResource("8")
 
-[node name="DynamicObjectMesh" type="MeshInstance3D" parent="." node_paths=PackedStringArray("ignore_unknown_object_toggle")]
+[node name="DynamicObjectMesh" type="MeshInstance3D" parent="." node_paths=PackedStringArray("ignore_unknown_object_toggle", "icon_visibility_toggle")]
 material_override = SubResource("26")
 mesh = SubResource("27")
 script = ExtResource("10")
 ignore_unknown_object_toggle = NodePath("../Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/IgnoreUnknownObjectContainer/IgnoreUnknownObjectToggle")
+icon_visibility_toggle = NodePath("../Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/ObjectIconContainer/ObjectIconToggle")
 
 [node name="HUD" type="CanvasLayer" parent="."]
 
@@ -584,6 +585,19 @@ focus_mode = 0
 script = ExtResource("37_782fw")
 dynamic_object_mesh_path = NodePath("../../../../../../../../../../DynamicObjectMesh")
 
+[node name="ObjectIconContainer" type="HBoxContainer" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body"]
+layout_mode = 2
+
+[node name="ObjectIconLabel" type="Label" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/ObjectIconContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Object Icon"
+
+[node name="ObjectIconToggle" type="CheckButton" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/ObjectIconContainer"]
+layout_mode = 2
+focus_mode = 0
+button_pressed = true
+
 [node name="DayModeContainer" type="HBoxContainer" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body"]
 layout_mode = 2
 
@@ -701,6 +715,7 @@ text = ">"
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionData/Body/PointCloudMapContainer/PointCloudMapToggle" to="PointCloudMapMesh" method="_on_point_cloud_map_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionData/Body/ObstacleSegmentationContainer/ObstacleSegmentationToggle" to="ObstacleSegmentationMesh" method="_on_obstacle_segmentation_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/IgnoreUnknownObjectContainer/IgnoreUnknownObjectToggle" to="DynamicObjectMesh" method="_on_ignore_unknown_object_toggle_toggled"]
+[connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/ObjectIconContainer/ObjectIconToggle" to="DynamicObjectMesh" method="set_icon_visibility"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/TopStatusBarContainer/TopStatusBarToggle" to="HUD/TopStatusBar" method="_on_top_bar_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/OperationControlContainer/OperationControlToggle" to="HUD/OperationControl" method="_on_operation_control_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/VehicleActuatorStatusContainer/VehicleActuatorStatusToggle" to="HUD/VehicleActuatorStatus" method="_on_vehicle_actuator_atatus_toggle_toggled"]

--- a/godot-project/Menu/ObjectModeOption.gd
+++ b/godot-project/Menu/ObjectModeOption.gd
@@ -6,7 +6,7 @@ class_name DynamicObjectRenderModeOption
 
 enum Preset {
 	MODEL_3D,
-	GEOMETRY
+	GEOMETRY,
 }
 
 var _suppress := false


### PR DESCRIPTION
### Motivation

- Provide a UI control to enable/disable 2D object icons (billboards) independently from 3D model/geometry rendering.
- Ensure the `DynamicObjectMesh` renderer initializes its icon visibility from the UI and can react to toggle events.
- Reset icon state when icons are hidden to avoid stale icon artifacts.

### Description

- Added an exported `icon_visibility_toggle` property and synchronization in `DynamicObjectMesh.gd` so `show_icons` is initialized from the UI toggle and a new `set_icon_visibility` method to change visibility at runtime.
- When icons are disabled via `set_icon_visibility`, the icon usage counters are reset and unused icons hidden by calling `_reset_icon_usage_counters()` and `_hide_unused_icons()`.
- Removed the redundant per-model inline icon placement in `_render_models` so icons are managed consistently by the icon rendering pass.
- Updated `Main.tscn` to add the `ObjectIconContainer` UI (label + `ObjectIconToggle`), wired the new toggle into the `DynamicObjectMesh` node via `icon_visibility_toggle` and added the signal connection to call `set_icon_visibility`.
- Minor formatting tweak in `ObjectModeOption.gd` (enum trailing comma) with no behavior change.

### Testing

- No automated tests exist for these UI/renderer scripts, so no automated test runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad96a4b9f4832a8165e9a91a881807)