### PR TITLE
Add High Contrast toggle for trajectory rendering and disable distance fade

### DIFF
--- a/godot-project/3DViewer/Main.tscn
+++ b/godot-project/3DViewer/Main.tscn
@@ -123,7 +123,7 @@ resource_name = "mesh"
 [sub_resource type="StandardMaterial3D" id="24"]
 shading_mode = 0
 vertex_color_use_as_albedo = true
-albedo_color = Color(1, 1, 1, 0.823529)
+albedo_color = Color(1, 1, 1, 1)
 distance_fade_mode = 1
 distance_fade_max_distance = 60.0
 
@@ -613,6 +613,18 @@ script = ExtResource("38_2kqhp")
 world_path = NodePath("../../../../../../../../../../World")
 ego_vehicle_path = NodePath("../../../../../../../../../../EgoVehicle")
 
+[node name="HighContrastContainer" type="HBoxContainer" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body"]
+layout_mode = 2
+
+[node name="HighContrastLabel" type="Label" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/HighContrastContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "High Contrast"
+
+[node name="HighContrastToggle" type="CheckButton" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/HighContrastContainer"]
+layout_mode = 2
+focus_mode = 0
+
 [node name="SelectionHUD" type="VBoxContainer" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content"]
 layout_mode = 2
 script = ExtResource("37_ow1tw")
@@ -716,6 +728,7 @@ text = ">"
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionData/Body/ObstacleSegmentationContainer/ObstacleSegmentationToggle" to="ObstacleSegmentationMesh" method="_on_obstacle_segmentation_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/IgnoreUnknownObjectContainer/IgnoreUnknownObjectToggle" to="DynamicObjectMesh" method="_on_ignore_unknown_object_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/ObjectIconContainer/ObjectIconToggle" to="DynamicObjectMesh" method="set_icon_visibility"]
+[connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/Selection3DEnvironment/Body/HighContrastContainer/HighContrastToggle" to="TrajectoryMesh" method="_on_high_contrast_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/TopStatusBarContainer/TopStatusBarToggle" to="HUD/TopStatusBar" method="_on_top_bar_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/OperationControlContainer/OperationControlToggle" to="HUD/OperationControl" method="_on_operation_control_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/VehicleActuatorStatusContainer/VehicleActuatorStatusToggle" to="HUD/VehicleActuatorStatus" method="_on_vehicle_actuator_atatus_toggle_toggled"]

--- a/godot-project/3DViewer/TrajectoryMesh.gd
+++ b/godot-project/3DViewer/TrajectoryMesh.gd
@@ -2,6 +2,7 @@ extends MeshInstance3D
 
 var trajectory = Trajectory.new()
 @export var wheelbase_to_front: float = 3.78
+var high_contrast_enabled: bool = false
 
 func velocity_to_normalized_value(velocity):
 	return clamp(velocity / 5.0, 0.0, 1.0)
@@ -9,8 +10,26 @@ func velocity_to_color(velocity):
 	var alpha = clamp(velocity_to_normalized_value(velocity), 0.2, 0.9)
 	return Color(0, 0.2, 1.0, alpha)
 
+func apply_high_contrast(_color: Color):
+	return Color(0.0, 1.0, 0.0, 1.0)
+
+func update_distance_fade_mode():
+	var trajectory_material = material_override as StandardMaterial3D
+	if trajectory_material == null:
+		return
+
+	if high_contrast_enabled:
+		trajectory_material.distance_fade_mode = BaseMaterial3D.DISTANCE_FADE_DISABLED
+	else:
+		trajectory_material.distance_fade_mode = BaseMaterial3D.DISTANCE_FADE_PIXEL_ALPHA
+
 func _ready():
 	trajectory.subscribe("/planning/trajectory", false)
+	update_distance_fade_mode()
+
+func _on_high_contrast_toggle_toggled(toggled_on):
+	high_contrast_enabled = toggled_on
+	update_distance_fade_mode()
 	
 func _process(_delta):
 	if !trajectory.has_new():
@@ -26,11 +45,14 @@ func _process(_delta):
 	var traj_colors = PackedColorArray()
 	# Create triangle
 	var trajectory_triangle_strip = trajectory.get_trajectory_triangle_strip(2.0)
+	var trajectory_color = Color(0.0, 0.02, 1.0, 0.8)
+	if high_contrast_enabled:
+		trajectory_color = apply_high_contrast(trajectory_color)
 	for point in trajectory_triangle_strip:
 		traj_verts.append(point["position"])
 		traj_normals.append(point["normal"])
 		#traj_uvs.append(Vector2(velocity_to_normalized_value(point["velocity"]), 0))
-		traj_colors.append(Color(0.0, 0.02, 1.0, 0.8))
+		traj_colors.append(trajectory_color)
 	traj_arr[Mesh.ARRAY_VERTEX] = traj_verts
 	traj_arr[Mesh.ARRAY_NORMAL] = traj_normals
 	traj_arr[Mesh.ARRAY_COLOR] = traj_colors
@@ -51,7 +73,10 @@ func _process(_delta):
 	for point in wall_triangle_strip:
 		wall_verts.append(point["position"])
 		wall_normals.append(point["normal"])
-		wall_colors.append(point["color"])
+		var wall_color = point["color"]
+		if high_contrast_enabled:
+			wall_color = apply_high_contrast(wall_color)
+		wall_colors.append(wall_color)
 	wall_arr[Mesh.ARRAY_VERTEX] = wall_verts
 	wall_arr[Mesh.ARRAY_NORMAL] = wall_normals
 	wall_arr[Mesh.ARRAY_COLOR] = wall_colors


### PR DESCRIPTION
### Motivation
- Provide a high-contrast display mode for trajectory visualization to improve visibility in low-contrast scenarios and allow disabling distance-based fading for clearer inspection of trajectory/wall geometry.

### Description
- Added a `HighContrast` UI row to `Main.tscn` with a `CheckButton` and a connection to `TrajectoryMesh` via `_on_high_contrast_toggle_toggled`.
- Added `high_contrast_enabled` state and `apply_high_contrast` helper in `TrajectoryMesh.gd` and apply high-contrast colors to both the trajectory and wall geometry when enabled.
- Implemented `update_distance_fade_mode` in `TrajectoryMesh.gd` to toggle the material `distance_fade_mode` between `DISTANCE_FADE_DISABLED` and `DISTANCE_FADE_PIXEL_ALPHA` based on `high_contrast_enabled` and call it from `_ready` and the toggle handler.
- Adjusted a material alpha in `Main.tscn` (changed `albedo_color` alpha from `0.823529` to `1`) to make the referenced material fully opaque.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad9c3df594832a9c25a4a52eb973aa)