### PR TITLE
Add vehicle actuator status size presets

### DIFF
--- a/godot-project/3DViewer/Main.tscn
+++ b/godot-project/3DViewer/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=65 format=3 uid="uid://cwhqdw3ex4dso"]
+[gd_scene load_steps=66 format=3 uid="uid://cwhqdw3ex4dso"]
 
 [ext_resource type="PackedScene" uid="uid://c12wli2xky3ja" path="res://3DViewer/Vehicle/RX450h/RX450h.tscn" id="1"]
 [ext_resource type="Script" path="res://3DViewer/EgoVehicle.gd" id="2"]
@@ -39,6 +39,7 @@
 [ext_resource type="Script" path="res://Menu/DayModeOption.gd" id="38_2kqhp"]
 [ext_resource type="Script" path="res://Menu/QuitButton.gd" id="38_d4rqi"]
 [ext_resource type="Script" path="res://Menu/WindowSettings.gd" id="39_w7msr"]
+[ext_resource type="Script" path="res://Menu/VehicleActuatorStatusSizeOption.gd" id="40_0if0g"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_m8ng5"]
 sky_top_color = Color(0, 0, 0, 1)
@@ -682,6 +683,19 @@ layout_mode = 2
 focus_mode = 0
 button_pressed = true
 
+[node name="VehicleActuatorStatusSizeContainer" type="HBoxContainer" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body"]
+layout_mode = 2
+
+[node name="VehicleActuatorStatusSizeLabel" type="Label" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/VehicleActuatorStatusSizeContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Steering/Meter Size"
+
+[node name="VehicleActuatorStatusSizeOption" type="OptionButton" parent="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/VehicleActuatorStatusSizeContainer"]
+layout_mode = 2
+focus_mode = 0
+script = ExtResource("40_0if0g")
+
 [node name="MarginContainer2" type="MarginContainer" parent="Menu/MenuSlide/MenuPanel/VBoxContainer"]
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
@@ -732,3 +746,4 @@ text = ">"
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/TopStatusBarContainer/TopStatusBarToggle" to="HUD/TopStatusBar" method="_on_top_bar_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/OperationControlContainer/OperationControlToggle" to="HUD/OperationControl" method="_on_operation_control_toggle_toggled"]
 [connection signal="toggled" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/VehicleActuatorStatusContainer/VehicleActuatorStatusToggle" to="HUD/VehicleActuatorStatus" method="_on_vehicle_actuator_atatus_toggle_toggled"]
+[connection signal="item_selected" from="Menu/MenuSlide/MenuPanel/VBoxContainer/ScrollContainer/Content/SelectionHUD/Body/VehicleActuatorStatusSizeContainer/VehicleActuatorStatusSizeOption" to="HUD/VehicleActuatorStatus" method="set_size_preset"]

--- a/godot-project/3DViewer/VehicleActuatorStatus.gd
+++ b/godot-project/3DViewer/VehicleActuatorStatus.gd
@@ -2,20 +2,7 @@ extends Control
 
 @export var vehicle_actuator_status_toggle: BaseButton
 
-@onready var steering_slot: Control = $HBoxContainer/SteeringSlot
-@onready var steering: Sprite2D = $HBoxContainer/SteeringSlot/Steering
-@onready var spacer: Control = $HBoxContainer/Spacer
-@onready var console_meter_slot: Control = $HBoxContainer/ConsoleMeterSlot
-@onready var console_meter: Sprite2D = $HBoxContainer/ConsoleMeterSlot/ConsoleMeter
-
-enum SizePreset {
-	XSMALL,
-	SMALL,
-	NORMAL,
-	LARGE,
-	XLARGE,
-}
-
+const DEFAULT_SIZE_PRESET := 2
 const ROOT_BOTTOM_OFFSET := -21.0
 const BASE_ROOT_SIZE := Vector2(274.0, 128.0)
 const BASE_SLOT_SIZE := Vector2(128.0, 128.0)
@@ -23,23 +10,24 @@ const BASE_SPACER_SIZE := Vector2(10.0, 0.0)
 const BASE_STEERING_POSITION := Vector2(64.0, 64.0)
 const BASE_CONSOLE_METER_POSITION := Vector2(64.0, 43.0)
 const BASE_ICON_SCALE := Vector2(0.5, 0.5)
-const PRESET_FACTORS := {
-	SizePreset.XSMALL: 0.5,
-	SizePreset.SMALL: 0.75,
-	SizePreset.NORMAL: 1.0,
-	SizePreset.LARGE: 1.25,
-	SizePreset.XLARGE: 1.5,
-}
+const SIZE_FACTORS := [0.5, 0.75, 1.0, 1.25, 1.5]
 
-func _ready():
+@onready var steering_slot: Control = $HBoxContainer/SteeringSlot
+@onready var steering: Sprite2D = $HBoxContainer/SteeringSlot/Steering
+@onready var spacer: Control = $HBoxContainer/Spacer
+@onready var console_meter_slot: Control = $HBoxContainer/ConsoleMeterSlot
+@onready var console_meter: Sprite2D = $HBoxContainer/ConsoleMeterSlot/ConsoleMeter
+
+func _ready() -> void:
 	visible = vehicle_actuator_status_toggle.button_pressed
-	set_size_preset(SizePreset.NORMAL)
+	set_size_preset(DEFAULT_SIZE_PRESET)
 
-func _on_vehicle_actuator_atatus_toggle_toggled(toggled_on):
+func _on_vehicle_actuator_atatus_toggle_toggled(toggled_on: bool) -> void:
 	visible = toggled_on
 
 func set_size_preset(preset: int) -> void:
-	var factor: float = PRESET_FACTORS.get(preset, PRESET_FACTORS[SizePreset.NORMAL])
+	var preset_index := clampi(preset, 0, SIZE_FACTORS.size() - 1)
+	var factor: float = SIZE_FACTORS[preset_index]
 	var root_size := BASE_ROOT_SIZE * factor
 
 	offset_left = -root_size.x / 2.0

--- a/godot-project/3DViewer/VehicleActuatorStatus.gd
+++ b/godot-project/3DViewer/VehicleActuatorStatus.gd
@@ -2,8 +2,56 @@ extends Control
 
 @export var vehicle_actuator_status_toggle: BaseButton
 
+@onready var steering_slot: Control = $HBoxContainer/SteeringSlot
+@onready var steering: Sprite2D = $HBoxContainer/SteeringSlot/Steering
+@onready var spacer: Control = $HBoxContainer/Spacer
+@onready var console_meter_slot: Control = $HBoxContainer/ConsoleMeterSlot
+@onready var console_meter: Sprite2D = $HBoxContainer/ConsoleMeterSlot/ConsoleMeter
+
+enum SizePreset {
+	XSMALL,
+	SMALL,
+	NORMAL,
+	LARGE,
+	XLARGE,
+}
+
+const ROOT_BOTTOM_OFFSET := -21.0
+const BASE_ROOT_SIZE := Vector2(274.0, 128.0)
+const BASE_SLOT_SIZE := Vector2(128.0, 128.0)
+const BASE_SPACER_SIZE := Vector2(10.0, 0.0)
+const BASE_STEERING_POSITION := Vector2(64.0, 64.0)
+const BASE_CONSOLE_METER_POSITION := Vector2(64.0, 43.0)
+const BASE_ICON_SCALE := Vector2(0.5, 0.5)
+const PRESET_FACTORS := {
+	SizePreset.XSMALL: 0.5,
+	SizePreset.SMALL: 0.75,
+	SizePreset.NORMAL: 1.0,
+	SizePreset.LARGE: 1.25,
+	SizePreset.XLARGE: 1.5,
+}
+
 func _ready():
 	visible = vehicle_actuator_status_toggle.button_pressed
+	set_size_preset(SizePreset.NORMAL)
 
 func _on_vehicle_actuator_atatus_toggle_toggled(toggled_on):
 	visible = toggled_on
+
+func set_size_preset(preset: int) -> void:
+	var factor: float = PRESET_FACTORS.get(preset, PRESET_FACTORS[SizePreset.NORMAL])
+	var root_size := BASE_ROOT_SIZE * factor
+
+	offset_left = -root_size.x / 2.0
+	offset_top = ROOT_BOTTOM_OFFSET - root_size.y
+	offset_right = root_size.x / 2.0
+	offset_bottom = ROOT_BOTTOM_OFFSET
+
+	steering_slot.custom_minimum_size = BASE_SLOT_SIZE * factor
+	console_meter_slot.custom_minimum_size = BASE_SLOT_SIZE * factor
+	spacer.custom_minimum_size = BASE_SPACER_SIZE * factor
+
+	steering.position = BASE_STEERING_POSITION * factor
+	console_meter.position = BASE_CONSOLE_METER_POSITION * factor
+	steering.scale = BASE_ICON_SCALE * factor
+	console_meter.scale = BASE_ICON_SCALE * factor

--- a/godot-project/Menu/VehicleActuatorStatusSizeOption.gd
+++ b/godot-project/Menu/VehicleActuatorStatusSizeOption.gd
@@ -1,28 +1,14 @@
 extends OptionButton
 
-enum Preset {
-	PERCENT_50,
-	PERCENT_75,
-	PERCENT_100,
-	PERCENT_125,
-	PERCENT_150,
-}
+const SIZE_LABELS := ["50%", "75%", "100%", "125%", "150%"]
+const DEFAULT_SIZE_PRESET := 2
 
 func _ready() -> void:
 	clear()
-	add_item("50%", Preset.PERCENT_50)
-	add_item("75%", Preset.PERCENT_75)
-	add_item("100%", Preset.PERCENT_100)
-	add_item("125%", Preset.PERCENT_125)
-	add_item("150%", Preset.PERCENT_150)
-	select(_find_index_by_id(Preset.PERCENT_100))
+	for label in SIZE_LABELS:
+		add_item(label)
+	select(DEFAULT_SIZE_PRESET)
 	call_deferred("_emit_initial_selection")
 
 func _emit_initial_selection() -> void:
-	item_selected.emit(_find_index_by_id(Preset.PERCENT_100))
-
-func _find_index_by_id(id: int) -> int:
-	for i in range(item_count):
-		if get_item_id(i) == id:
-			return i
-	return 0
+	item_selected.emit(DEFAULT_SIZE_PRESET)

--- a/godot-project/Menu/VehicleActuatorStatusSizeOption.gd
+++ b/godot-project/Menu/VehicleActuatorStatusSizeOption.gd
@@ -1,0 +1,28 @@
+extends OptionButton
+
+enum Preset {
+	PERCENT_50,
+	PERCENT_75,
+	PERCENT_100,
+	PERCENT_125,
+	PERCENT_150,
+}
+
+func _ready() -> void:
+	clear()
+	add_item("50%", Preset.PERCENT_50)
+	add_item("75%", Preset.PERCENT_75)
+	add_item("100%", Preset.PERCENT_100)
+	add_item("125%", Preset.PERCENT_125)
+	add_item("150%", Preset.PERCENT_150)
+	select(_find_index_by_id(Preset.PERCENT_100))
+	call_deferred("_emit_initial_selection")
+
+func _emit_initial_selection() -> void:
+	item_selected.emit(_find_index_by_id(Preset.PERCENT_100))
+
+func _find_index_by_id(id: int) -> int:
+	for i in range(item_count):
+		if get_item_id(i) == id:
+			return i
+	return 0


### PR DESCRIPTION
## Summary
- add a menu option to change the steering and meter HUD size
- apply size presets to the vehicle actuator status control layout and sprites
- connect the new option in Main.tscn and default it to 100%

## Testing
- not run