### PR TITLE
Tune turn-indicator camera behavior

### DIFF
--- a/godot-project/3DViewer/Camera.gd
+++ b/godot-project/3DViewer/Camera.gd
@@ -6,30 +6,35 @@ const MODE_OFFSET := 1
 const MODE_ROT := 2
 
 # --- Cache node references to avoid repeated lookups ---
+@onready var ego_vehicle: Node = get_parent()
 @onready var horizon: Node3D = $Horizon
 @onready var vertical: Node3D = $Horizon/Vertical
 @onready var view_camera: Camera3D = $Horizon/Vertical/ViewCamera
 
 # --- Original data structure preserved (no logic change) ---
 var view_mode = [
-	["tpv", Vector3(-8, 4, 0), Vector3(deg_to_rad(-20), deg_to_rad(-90), deg_to_rad(0))],
+	["tpv", Vector3(-9, 4.25, 0), Vector3(deg_to_rad(-25), deg_to_rad(-90), deg_to_rad(0))],
 	["bev", Vector3(0, 100, 0), Vector3(deg_to_rad(-90), deg_to_rad(0), deg_to_rad(0))]
 ]
 
 # --- State variables (unchanged semantics) ---
-var current_view_mode = 0
-var mouse_sensitivity = 0.5
-var camera_rotation_h = 0.0
-var camera_rotation_v = 0.0
-var camera_zoom_ratio = 1.0
-var camera_zoom_change_ratio = 0.95
-var enable_camera_rotation = false
+var current_view_mode: int = 0
+var mouse_sensitivity: float = 0.5
+var camera_rotation_h: float = 0.0
+var camera_rotation_v: float = 0.0
+var camera_zoom_ratio: float = 1.0
+var camera_zoom_change_ratio: float = 0.95
+@export var turn_signal_camera_offset: Vector3 = Vector3(-6.0, 18.0, 0.0)
+@export var turn_signal_camera_pitch_deg: float = 45.0
+@export var turn_signal_transition_speed: float = 0.72
+var enable_camera_rotation: bool = false
 var touch_points := {}
-var prev_pinch_distance := -1.0
-var auto_return_enabled = true
-var auto_return_speed = 2.0
-var auto_return_delay = 2.0
-var _auto_return_timer = 0.0
+var prev_pinch_distance: float = -1.0
+var auto_return_enabled: bool = true
+var auto_return_speed: float = 2.0
+var auto_return_delay: float = 2.0
+var _auto_return_timer: float = 0.0
+var turn_signal_view_blend: float = 0.0
 
 func _is_touch_gesture_active() -> bool:
 	return touch_points.size() > 0
@@ -44,6 +49,28 @@ func _mode_offset(idx: int) -> Vector3:
 func _mode_rot(idx: int) -> Vector3:
 	return view_mode[idx][MODE_ROT]
 
+func _is_turn_signal_active() -> bool:
+	if not is_instance_valid(ego_vehicle):
+		return false
+	if not ego_vehicle.has_method("is_turn_indicator_active"):
+		return false
+	return bool(ego_vehicle.call("is_turn_indicator_active"))
+
+func _effective_camera_offset() -> Vector3:
+	var offset: Vector3 = _mode_offset(current_view_mode)
+	if _mode_name(current_view_mode) == "tpv":
+		offset += turn_signal_camera_offset * turn_signal_view_blend
+	return offset
+
+func _effective_camera_position() -> Vector3:
+	return _effective_camera_offset() * camera_zoom_ratio
+
+func _effective_camera_rotation() -> Vector3:
+	var target_rotation: Vector3 = _mode_rot(current_view_mode)
+	if _mode_name(current_view_mode) == "tpv":
+		target_rotation.x = lerpf(target_rotation.x, deg_to_rad(-turn_signal_camera_pitch_deg), turn_signal_view_blend)
+	return target_rotation
+
 # --- Initialization helpers (same behavior as original) ---
 func init_camera_rotation():
 	# Reset stored horizontal/vertical rotations and apply immediately to pivot nodes (degrees)
@@ -55,17 +82,22 @@ func init_camera_rotation():
 func init_camera_translation():
 	# Reset zoom and snap camera to mode offset * zoom (position only)
 	camera_zoom_ratio = 1.0
-	view_camera.set_position(_mode_offset(current_view_mode) * camera_zoom_ratio)
+	view_camera.set_position(_effective_camera_position())
 
 func set_camera_translation():
 	# Apply current offset * zoom to camera (position only)
-	view_camera.set_position(_mode_offset(current_view_mode) * camera_zoom_ratio)
+	view_camera.set_position(_effective_camera_position())
 
 func _ready():
 	# Keep original no-op (explicitly preserve behavior)
 	pass
 
 func _process(delta):
+	var turn_signal_target_blend: float = 0.0
+	if _is_turn_signal_active():
+		turn_signal_target_blend = 1.0
+	turn_signal_view_blend = lerpf(turn_signal_view_blend, turn_signal_target_blend, delta * turn_signal_transition_speed)
+
 	# Auto-return: when not dragging, gradually reset rotation and zoom
 	if auto_return_enabled and not enable_camera_rotation and not _is_touch_gesture_active():
 		_auto_return_timer += delta
@@ -79,16 +111,18 @@ func _process(delta):
 	horizon.rotation_degrees.y = lerp(horizon.rotation_degrees.y, camera_rotation_h, delta * 10)
 	vertical.rotation_degrees.z = lerp(vertical.rotation_degrees.z, camera_rotation_v, delta * 10)
 
-	# Smoothly interpolate camera position towards offset * zoom
-	var target_pos = _mode_offset(current_view_mode) * camera_zoom_ratio
+	# Smoothly interpolate camera transform towards the turn-signal view
+	var target_pos: Vector3 = _effective_camera_position()
 	view_camera.set_position(lerp(view_camera.get_position(), target_pos, delta * 5))
+	var target_rot: Vector3 = _effective_camera_rotation()
+	view_camera.set_rotation(view_camera.get_rotation().lerp(target_rot, delta * 5.0))
 
 func _unhandled_input(event):
 	# Toggle view mode and apply mode rotation/position, then reset rot/zoom as in original
 	if Input.is_action_just_pressed("ui_view_switch"):
 		current_view_mode = (current_view_mode + 1) % view_mode.size()
-		view_camera.set_position(_mode_offset(current_view_mode))
-		view_camera.set_rotation(_mode_rot(current_view_mode))
+		view_camera.set_position(_effective_camera_position())
+		view_camera.set_rotation(_effective_camera_rotation())
 		init_camera_rotation()
 		init_camera_translation()
 

--- a/godot-project/3DViewer/EgoVehicle.gd
+++ b/godot-project/3DViewer/EgoVehicle.gd
@@ -44,6 +44,9 @@ func _process(delta):
 			vehicle_body.turn_off_left_signal()
 		vehicle_status.set_old()
 
+func is_turn_indicator_active() -> bool:
+	return vehicle_status.is_turn_on_right() or vehicle_status.is_turn_on_left()
+
 func set_night_mode(enabled: bool) -> void:
 	vehicle_body.set_night_mode(enabled)
 	head_beam_light.visible = enabled


### PR DESCRIPTION
## Summary
- add a turn-indicator-driven camera transition for TPV mode
- smooth the turn-indicator camera position and pitch changes, and restore the default view when indicators turn off
- retune the default TPV offset and pitch for a slightly higher and farther baseline view

## Testing
- Not run in Godot editor here; local startup verification is blocked by a missing shared library in this environment: libautoware_lanelet2_extension_lib.so